### PR TITLE
Update tests for EC2 ephemeral disk changes

### DIFF
--- a/nephoria/aws/ec2/ec2ops.py
+++ b/nephoria/aws/ec2/ec2ops.py
@@ -197,6 +197,7 @@ class EucaVmType(EC2Object):
         self.memory = None
         self.cpu = None
         self.disk = None
+        self.diskCount = None
         self.networkinterfaces = None
         self.region = None
         self.availability = None
@@ -220,6 +221,8 @@ class EucaVmType(EC2Object):
                 self.cpu = int(value)
             if ename == 'disk':
                 self.disk = int(value)
+            if ename == 'diskcount':
+                self.diskCount = int(value)
             if ename == 'memory':
                 self.memory = int(value)
             else:
@@ -7039,6 +7042,7 @@ disable_root: false"""
                     base.index = vmtype.index
                 base.cpu = vmtype.cpu or base.cpu
                 base.disk = vmtype.disk or base.disk
+                base.diskCount = vmtype.diskCount or base.diskCount
                 base.memory = vmtype.memory or base.memory
                 base.region = vmtype.region or base.region
                 base.networkinterfaces = vmtype.networkinterfaces or base.networkinterfaces

--- a/nephoria/aws/ec2/euinstance.py
+++ b/nephoria/aws/ec2/euinstance.py
@@ -2410,6 +2410,9 @@ class EuInstance(Instance, TaggedResource, Machine):
     def check_ephemeral_against_vmtype(self):
         gb = 1073741824
 
+        if self.vmtype_info.diskCount == 0:
+            return None
+
         size = self.vmtype_info.disk
         ephemeral_dev = self.get_ephemeral_dev()
         block_size = self.get_blockdev_size_in_bytes(ephemeral_dev)

--- a/nephoria/testcases/ec2/ebs/block_dev_map_suite.py
+++ b/nephoria/testcases/ec2/ebs/block_dev_map_suite.py
@@ -828,8 +828,9 @@ class Block_Device_Mapping_Tests(CliTestRunner):
                                                                                 map_device=bdm_snapshot_dev)
             self.status('Checking instance for ephemeral disk and size...')
             guest_ephemeral_dev = instance.check_ephemeral_against_vmtype()
+            guest_ephemeral_dev_list = [] if guest_ephemeral_dev is None else [guest_ephemeral_dev]
             self.status("Ephemeral verified, Attempting to find guest's device empty volume by process of elimination...")
-            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev, guest_ephemeral_dev])
+            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev] + guest_ephemeral_dev_list)
             if len(remaining_devs) != 1:
                 raise Exception('Could not find empty vol dev from remaining devs on guest:' + str(",").join(remaining_devs))
             guest_emptyvol_device = '/dev/' + str(remaining_devs[0]).replace('/dev/','')
@@ -934,8 +935,9 @@ class Block_Device_Mapping_Tests(CliTestRunner):
                                                                                 map_device=bdm_snapshot_dev)
             self.status('Checking instance for ephemeral disk and size...')
             guest_ephemeral_dev = instance.check_ephemeral_against_vmtype()
+            guest_ephemeral_dev_list = [] if guest_ephemeral_dev is None else [guest_ephemeral_dev]
             self.status("Attempting to find guest's device empty volume by process of elimination...")
-            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev, guest_ephemeral_dev])
+            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev] + guest_ephemeral_dev_list)
             if len(remaining_devs) != 1:
                 raise Exception('Could not find empty vol dev from remaining devs on guest:' + str(",").join(remaining_devs))
             guest_emptyvol_device = '/dev/' + str(remaining_devs[0]).replace('/dev/','')
@@ -1118,6 +1120,7 @@ class Block_Device_Mapping_Tests(CliTestRunner):
             self.user.ec2.show_block_device_map(instance.block_device_mapping)
             self.status('Checking instance for ephemeral disk and size...')
             guest_ephemeral_dev = instance.check_ephemeral_against_vmtype()
+            guest_ephemeral_dev_list = [] if guest_ephemeral_dev is None else [guest_ephemeral_dev]
             self.status('Checking instance devices for md5sums which match original volume/snapshots.\nThis step will also \
                          record the volume id, md5 and guest device within the instance for later stop, start, and detach \
                          operations...')
@@ -1142,7 +1145,7 @@ class Block_Device_Mapping_Tests(CliTestRunner):
 
             #Empty vol checks...
             self.status("Attempting to find guest's device empty volume by process of elimination...")
-            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev, guest_ephemeral_dev])
+            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev] + guest_ephemeral_dev_list)
             if len(remaining_devs) != 1:
                 raise Exception('Could not find empty vol dev from remaining devs on guest:' + str(",").join(remaining_devs))
             guest_emptyvol_device = '/dev/' + str(remaining_devs[0]).replace('/dev/','')
@@ -1280,6 +1283,7 @@ class Block_Device_Mapping_Tests(CliTestRunner):
             self.user.ec2.show_block_device_map(instance.block_device_mapping)
             self.status('Checking instance for ephemeral disk and size...')
             guest_ephemeral_dev = instance.check_ephemeral_against_vmtype()
+            guest_ephemeral_dev_list = [] if guest_ephemeral_dev is None else [guest_ephemeral_dev]
 
             self.status('Checking instance devices for md5sums which match original volume/snapshots.\nThis step will also \
                          record the volume id, md5 and guest device within the instance for later stop, start, and detach \
@@ -1302,7 +1306,7 @@ class Block_Device_Mapping_Tests(CliTestRunner):
                                 ', the size requested for bdm snap:' + str(self.base_test_snapshot.id))
 
             self.status("Attempting to find guest's device empty volume by process of elimination...")
-            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev, guest_ephemeral_dev])
+            remaining_devs=self.find_remaining_devices(instance,[guest_root_dev, guest_snap_dev] + guest_ephemeral_dev_list)
             if len(remaining_devs) != 1:
                 raise Exception('Could not find empty vol dev from remaining devs on guest:' + str(",").join(remaining_devs))
             guest_emptyvol_device = '/dev/' + str(remaining_devs[0]).replace('/dev/','')


### PR DESCRIPTION
Update ebs test to allow for instance types without any ephemeral disk.

Demo is that tests pass as expected with this change in place.